### PR TITLE
Fix formatting of bullet list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Play simulated games of Jeopardy with real questions from the show! Keep track o
 
 Features
 ========
-*Pulls questions from JService.io to fill a simulated Jeopardy board with 30 questions from 6 categories per round
-*Tracks and save scores so you can see your progress over time
-*Tens of thousands of non-repeating questions
 
+* Pulls questions from JService.io to fill a simulated Jeopardy board with 30 questions from 6 categories per round
+
+* Tracks and save scores so you can see your progress over time
+
+* Tens of thousands of non-repeating questions


### PR DESCRIPTION
Markdown lists require a space after the bullet `*` and one empty line between list items to be formatted properly.